### PR TITLE
fix affected rows conversoin bug when the number of row is large

### DIFF
--- a/plugSrc/mysql/build/entry.go
+++ b/plugSrc/mysql/build/entry.go
@@ -232,7 +232,7 @@ func (stm *stream) resolveServerPacket(payload []byte, seq int) {
 
 		case 0x00:
 			var pos = 1
-			l,_ := LengthBinary(payload[pos:])
+			l,_,_ := LengthEncodedInt(payload[pos:])
 			affectedRows := int(l)
 
 			msg += GetNowStr(false)+"%s Effect Row:%s"


### PR DESCRIPTION
## related issue

https://github.com/40t/go-sniffer/issues/29

https://github.com/40t/go-sniffer/issues/16 ?

## how to reproduce error

execute query which affected rows is over 2 byte-integer

```
taka-h@127.0.0.1 [sbtest] > desc sbtest1;
+-------+-----------+------+-----+---------+----------------+
| Field | Type      | Null | Key | Default | Extra          |
+-------+-----------+------+-----+---------+----------------+
| id    | int(11)   | NO   | PRI | NULL    | auto_increment |
| c     | char(120) | NO   |     |         |                |
+-------+-----------+------+-----+---------+----------------+
4 rows in set (0.00 sec)

taka-h@127.0.0.1 [sbtest] > update sbtest1 set c='fuga' where id<100000;
Query OK, 99999 rows affected (0.24 sec)
Rows matched: 99999  Changed: 99999  Warnings: 0
```

## Note

the type of 'affected rows' is `packet-Protocol::LengthEncodedInteger`, `LengthEncodedInt` is appropriate 

refs.
https://dev.mysql.com/doc/internals/en/integer.html#packet-Protocol::LengthEncodedInteger
https://dev.mysql.com/doc/internals/en/packet-OK_Packet.html